### PR TITLE
Don't release GL context at end of paintGL() (fixes Qt 6.11 crash on Linux)

### DIFF
--- a/QTerrainRenderer/src/render_widget/paint_gl.cpp
+++ b/QTerrainRenderer/src/render_widget/paint_gl.cpp
@@ -46,9 +46,10 @@ void RenderWidget::paintGL()
     break;
   }
 
-#ifdef __linux__
-  this->doneCurrent();
-#endif
+  // NOTE: do NOT call doneCurrent() here. paintGL() is a Qt override; Qt keeps
+  // the GL context current after it returns to run invalidateFboAfterPainting()
+  // (glInvalidateFramebuffer). Releasing the context here leaves
+  // QOpenGLContext::currentContext()==nullptr and crashes inside Qt 6.11.
 }
 
 } // namespace qtr


### PR DESCRIPTION
## Summary

Fixes a crash on Linux under Qt 6.11 caused by releasing the OpenGL context at the end of `RenderWidget::paintGL()`.

`paintGL()` is a Qt override, and Qt keeps the GL context current **after** it returns so it can run `invalidateFboAfterPainting()` (`glInvalidateFramebuffer`). The Linux-only `doneCurrent()` call released the context too early, leaving `QOpenGLContext::currentContext() == nullptr` and crashing inside Qt 6.11.

This removes the call and adds a comment documenting why it must not be reintroduced.

```diff
-#ifdef __linux__
-  this->doneCurrent();
-#endif
+  // NOTE: do NOT call doneCurrent() here. paintGL() is a Qt override; Qt keeps
+  // the GL context current after it returns to run invalidateFboAfterPainting()
+  // (glInvalidateFramebuffer). Releasing the context here leaves
+  // QOpenGLContext::currentContext()==nullptr and crashes inside Qt 6.11.
```

## File

- `QTerrainRenderer/src/render_widget/paint_gl.cpp`

## Notes

This change was drafted with AI assistance and has been personally reviewed by the sponsor, who is the point of contact for the review.

Sponsor: @barrulus
