### PR TITLE
Harden RenderWidget: GL-init failure handling + ImGui shutdown context

### DIFF
--- a/QTerrainRenderer/include/qtr/render_widget.hpp
+++ b/QTerrainRenderer/include/qtr/render_widget.hpp
@@ -304,6 +304,7 @@ private:
   GLuint                         fbo;
   GLuint                         fbo_depth;
   bool                           initial_gl_done = false;
+  bool                           gl_init_failed = false;
 
   // --- Scene components
   Camera camera_shadow_pass;

--- a/QTerrainRenderer/src/render_widget/render_widget.cpp
+++ b/QTerrainRenderer/src/render_widget/render_widget.cpp
@@ -77,12 +77,18 @@ RenderWidget::~RenderWidget()
 {
   if (this->context())
   {
-    // don't try to make context current in destructor Qt might have
-    // already destroyed the context
+    // make THIS widget's GL context current before the ImGui backend
+    // shutdown: it issues glDelete* calls on buffer/program names that only
+    // exist in this widget's context. With another widget's context current,
+    // those deletes destroy the OTHER widget's identically-numbered objects,
+    // and its next ImGui draw segfaults (unbound element buffer -> index
+    // offset read as a client pointer at ~NULL)
+    this->makeCurrent();
     ImGui::SetCurrentContext(this->imgui_context);
     ImGui_ImplOpenGL3_Shutdown();
     ImGui::DestroyContext(this->imgui_context);
     this->imgui_context = nullptr;
+    this->doneCurrent();
   }
 }
 

--- a/QTerrainRenderer/src/render_widget/render_widget.cpp
+++ b/QTerrainRenderer/src/render_widget/render_widget.cpp
@@ -75,7 +75,7 @@ RenderWidget::RenderWidget(const std::string &_title, QWidget *parent)
 
 RenderWidget::~RenderWidget()
 {
-  if (this->context())
+  if (this->context() && this->imgui_context)
   {
     // make THIS widget's GL context current before the ImGui backend
     // shutdown: it issues glDelete* calls on buffer/program names that only
@@ -158,6 +158,10 @@ void RenderWidget::initializeGL()
         "RenderWidget::initializeGL: {} - 3D view disabled for this widget",
         why);
     this->gl_init_failed = true;
+
+    // no ImGui context exists on this path: the input handlers dereference
+    // it via get_imgui_io, so stop all input by disabling the widget
+    this->setEnabled(false);
 
     // deferred: popping a modal dialog from inside initializeGL is unsafe
     QTimer::singleShot(0,

--- a/QTerrainRenderer/src/render_widget/render_widget.cpp
+++ b/QTerrainRenderer/src/render_widget/render_widget.cpp
@@ -159,6 +159,34 @@ void RenderWidget::initializeGL()
         why);
     this->gl_init_failed = true;
 
+    // log what was actually obtained, not what was asked for: without this the
+    // failure message says nothing about why resolution failed. Uses only
+    // QOpenGLContext / QOpenGLFunctions (the ES2 subset, always resolvable) --
+    // the 3.3-core table is what just failed.
+    if (QOpenGLContext *ctx = this->context())
+    {
+      const QSurfaceFormat obtained = ctx->format();
+      const char          *renderer = nullptr;
+
+      if (QOpenGLFunctions *fns = ctx->functions())
+      {
+        fns->initializeOpenGLFunctions();
+        renderer = reinterpret_cast<const char *>(
+            fns->glGetString(GL_RENDERER));
+      }
+
+      qtr::Logger::log()->critical(
+          "RenderWidget::initializeGL: obtained context was OpenGL {}.{} {} "
+          "profile, renderer: {}",
+          obtained.majorVersion(),
+          obtained.minorVersion(),
+          obtained.profile() == QSurfaceFormat::CoreProfile ? "core"
+          : obtained.profile() == QSurfaceFormat::CompatibilityProfile
+              ? "compatibility"
+              : "no",
+          renderer ? renderer : "unknown");
+    }
+
     // no ImGui context exists on this path: the input handlers dereference
     // it via get_imgui_io, so stop all input by disabling the widget
     this->setEnabled(false);
@@ -429,7 +457,11 @@ void RenderWidget::resizeEvent(QResizeEvent *event)
 
 void RenderWidget::resizeGL(int w, int h)
 {
-  if (!isValid())
+  // isValid() is not enough: when initializeOpenGLFunctions() fails the context
+  // is still valid, only the versioned function table is unresolved, so
+  // glViewport below would call through a null pointer. setEnabled(false) stops
+  // input events but Qt keeps delivering resize/paint. Same guard as paintGL.
+  if (!isValid() || !this->initial_gl_done)
     return;
 
   this->makeCurrent();

--- a/QTerrainRenderer/src/render_widget/render_widget.cpp
+++ b/QTerrainRenderer/src/render_widget/render_widget.cpp
@@ -5,6 +5,8 @@
 #include <stdexcept>
 
 #include <QOpenGLFunctions>
+#include <QMessageBox>
+#include <QSurfaceFormat>
 
 #include "imgui_impl_glfw.h"
 #include "imgui_impl_opengl3.h"
@@ -25,6 +27,15 @@ RenderWidget::RenderWidget(const std::string &_title, QWidget *parent)
     : QOpenGLWidget(parent), title(_title)
 {
   qtr::Logger::log()->trace("RenderWidget::RenderWidget");
+
+  // NOTE: deliberately no setFormat() here. Requesting 3.3 core per-widget
+  // makes initializeOpenGLFunctions() fail on every run on the Windows/NVIDIA
+  // test machine, including single-viewport projects that worked before -- the
+  // application already runs a QtWebEngine global shared context, and a
+  // per-widget format that conflicts with it cannot be honoured. The driver's
+  // default context does expose 3.3 core there. If a machine is ever found
+  // where the default context is genuinely too old, the fix belongs in a
+  // QSurfaceFormat::setDefaultFormat() call before QApplication, not here.
 
   this->setWindowTitle(this->title.c_str());
   this->setFocusPolicy(Qt::StrongFocus);
@@ -79,6 +90,11 @@ void RenderWidget::clear()
 {
   qtr::Logger::log()->trace("RenderWidget::clear");
 
+  // nothing was created if GL init never completed, and the calls below would
+  // run through unresolved 3.3-core function pointers
+  if (!this->initial_gl_done)
+    return;
+
   this->makeCurrent();
 
   this->reset_heightmap_geometry();
@@ -130,7 +146,57 @@ void RenderWidget::initializeGL()
 
   this->makeCurrent();
 
-  this->initializeOpenGLFunctions();
+  const auto fail_init = [this](const char *why)
+  {
+    qtr::Logger::log()->critical(
+        "RenderWidget::initializeGL: {} - 3D view disabled for this widget",
+        why);
+    this->gl_init_failed = true;
+
+    // deferred: popping a modal dialog from inside initializeGL is unsafe
+    QTimer::singleShot(0,
+                       this,
+                       [this]()
+                       {
+                         QMessageBox::critical(
+                             this,
+                             "3D view unavailable",
+                             "The 3D view could not initialize OpenGL 3.3 "
+                             "(core profile) on this system.\nSee the log for "
+                             "details.");
+                       });
+  };
+
+  if (!this->context() || !this->context()->isValid())
+  {
+    fail_init("no valid OpenGL context");
+    return;
+  }
+
+  if (!this->initializeOpenGLFunctions())
+  {
+    fail_init("OpenGL 3.3 core functions could not be resolved");
+    return;
+  }
+
+  // info level so it shows in release logs: the first thing needed when
+  // debugging driver-specific issues (e.g. otto-link/Hesiod#537)
+  {
+    const QSurfaceFormat obtained = this->context()->format();
+    const char *vendor = reinterpret_cast<const char *>(glGetString(GL_VENDOR));
+    const char *renderer = reinterpret_cast<const char *>(
+        glGetString(GL_RENDERER));
+
+    qtr::Logger::log()->info(
+        "RenderWidget::initializeGL: OpenGL {}.{} {} profile, vendor: {}, "
+        "renderer: {}",
+        obtained.majorVersion(),
+        obtained.minorVersion(),
+        obtained.profile() == QSurfaceFormat::CoreProfile ? "core"
+                                                          : "compatibility",
+        vendor ? vendor : "unknown",
+        renderer ? renderer : "unknown");
+  }
 
   // --- Shaders
 


### PR DESCRIPTION
## Summary

Four commits hardening `RenderWidget` against a GL context that cannot supply what the widget assumes, plus one confirmed teardown crash fix.

**This PR has been rewritten.** It previously bundled the ImGui-context ordering fix for otto-link/Hesiod#537 and a commit requesting an explicit 3.3-core surface format. The #537 fix now has its own PR — #23, confirmed on two platforms, and it should not wait on review of the rest. The format request has been **dropped as harmful** — see below.

The two branches touch disjoint files (#23 is `render_3d.cpp` only, this one is `render_widget.{cpp,hpp}` only), so they merge independently in either order.

### Confirmed crash — viewer destruction deleting a survivor's GL objects

`~RenderWidget` ran `ImGui_ImplOpenGL3_Shutdown()` without making its own GL context current, so its `glDelete*` calls landed in whatever context happened to be current. Every widget's ImGui backend allocates the same early buffer/program names in its own context, so a dying viewer could delete a *surviving* viewer's buffers; the survivor's next ImGui draw then ran with an unbound element buffer and segfaulted inside Mesa reading the index offset as a client pointer. Root-caused from a symbolised core dump (backend handles live, element-buffer bind rejected, `imgui_impl_opengl3.cpp:653`). Reachable whenever one of several viewports is destroyed.

### Hardening — unchecked `initializeOpenGLFunctions()`

The `initializeOpenGLFunctions()` return value was never checked, so on a context that cannot supply `QOpenGLFunctions_3_3_Core` every later GL call runs through unresolved function pointers. Now: log critical, disable the widget (its input handlers dereference the ImGui context), show a deferred message box, skip `clear()` and `resizeGL()` for never-initialised state, and log the *obtained* context (version/profile/`GL_VENDOR`/`GL_RENDERER`) so driver-specific reports arrive with that information already in the log.

**Honest status: this path has no confirmed repro.** The only way we ever triggered it was a bug of our own making (below). It is defensive work against an unchecked return value, not a fix for an observed crash.

### Dropped: explicit 3.3-core `setFormat()` request

An earlier revision of this PR added a per-widget `QSurfaceFormat` request for 3.3 core. **Do not do this.** On Windows/NVIDIA it made `initializeOpenGLFunctions()` fail on *every* run, including single-viewport projects that worked before — disabling the 3D view unconditionally. Hesiod hosts a QtWebEngine global shared context (`QWebEngineView`), which a conflicting per-widget format cannot override; the driver's default context there is 4.6 compatibility, which resolves the 3.3-core function table perfectly well. If a machine is ever found where the default context is genuinely too old, this belongs in a `QSurfaceFormat::setDefaultFormat()` call before `QApplication`, not in a widget constructor.

That regression is also what exposed the missing `resizeGL()` guard: `gl_init_failed` was assigned and never read, and `resizeGL()` guarded only on `isValid()`, which stays true when the context is valid and only versioned-function resolution failed — so `glViewport` ran through a null pointer (`AV read 0x10`). `setEnabled(false)` stops input events, not resize/paint delivery.

## Verification

Linux (Wayland/niri, Mesa, Intel ARL iGPU, Qt 6.11): destruction repro passes; repeated project-load churn with 2–3 saved viewports, close/reopen cycles, and quit-with-viewports-open all clean.

Windows 11 (NVIDIA RTX 5060 Laptop, driver 32.0.16.1074, Qt 6.10.0, MSVC; QEMU/KVM guest with VFIO GPU passthrough): repeated open/close of 2- and 3-viewport projects clean, GL init succeeds on every widget (obtained context logged as OpenGL 4.6 compatibility).

## Follow-ups deliberately not in this PR

- `initializeGL` re-run on GL context recreation creates a second ImGui context and leaks the first (leak only, no crash now).
- On Windows/NVIDIA we also captured four dumps faulting in `nvoglv64!DrvPresentBuffers` (AV read `0x0`) during Qt's backing-store composite. Different signature from anything fixed here, still unexplained, **not** claimed as fixed. Debugging note for whoever picks it up: with NVIDIA *Threaded Optimization* left on, the faulting thread is a driver worker with no app frames and is unattributable; turning it off for the process moves the same fault onto the main thread with a usable stack.
