### PR TITLE
fix: select own ImGui context before GetIO() in render_ui_render_3d

### DIFF
--- a/QTerrainRenderer/src/render_widget/render_3d.cpp
+++ b/QTerrainRenderer/src/render_widget/render_3d.cpp
@@ -164,13 +164,17 @@ void RenderWidget::render_scene_render_3d()
 
 void RenderWidget::render_ui_render_3d()
 {
+  // must precede any ImGui call: destroying another RenderWidget leaves the
+  // global current context null (its destructor destroys the context it
+  // selected), and GetIO() dereferences the global
+  ImGui::SetCurrentContext(this->imgui_context);
+
   {
     const float dpr = this->devicePixelRatioF();
     ImGuiIO    &io = ImGui::GetIO();
     io.DisplaySize = ImVec2(float(this->width()) * dpr, float(this->height()) * dpr);
   }
 
-  ImGui::SetCurrentContext(this->imgui_context);
   ImGui_ImplOpenGL3_NewFrame();
   ImGui::NewFrame();
 


### PR DESCRIPTION
## Summary

One-line ordering fix in `render_ui_render_3d()`: select this widget's ImGui context **before** reading `ImGui::GetIO()`. Fixes otto-link/Hesiod#537, and is reachable in released code today.

`~RenderWidget` calls `ImGui::DestroyContext()`, which nulls the global `GImGui` when the context being destroyed is the current one. So destroying any `RenderWidget` leaves no current ImGui context. `render_ui_render_3d()` then read `ImGui::GetIO()` — which dereferences that global — and only called `SetCurrentContext()` afterwards. With two or more viewports open, closing one segfaults the *survivor's* next paint. The 2D path already had the correct order.

## Confirmed on two platforms, on unmodified `main`

**Linux** (Wayland/niri, Mesa, Intel ARL iGPU, Qt 6.11): SEGV at `0x10` in the survivor's paint after closing one of two viewports.

**Windows 11** (NVIDIA RTX 5060 Laptop, driver 32.0.16.1074, Qt 6.10.0, MSVC, RelWithDebInfo; QEMU/KVM guest with VFIO GPU passthrough), from a full symbolised crash dump:

```
AV WRITE to 0x14 at qtr::RenderWidget::render_ui_render_3d+0x5f
  render_3d.cpp:170   movss dword ptr [rbx+0Ch],xmm6   ; io.DisplaySize = ...
  rbx = 0x0000000000000008        hesiod!GImGui = 0x0000000000000000

  qtr::RenderWidget::render_ui_render_3d+0x5f
  Qt6OpenGLWidgets!QOpenGLWidget::paintEvent+0x3f
  Qt6Widgets!QWidgetPrivate::sendPaintEvent
  Qt6Widgets!QWidgetRepaintManager::paintAndFlush
  ...
  hesiod!main+0x287
```

`GImGui` is exactly `nullptr`, so `GetIO()` returns `&((ImGuiContext*)0)->IO` = `0x8`, and the write to `io.DisplaySize` at `+0xC` faults at `0x14`. The fault address differs slightly from the Linux one (`0x10` vs `0x14`) because the two builds differ in ImGui version and which field is written first; the mechanism — a null current context — is identical.

## Repro

1. Launch, then **File > Open** a project with 2+ saved viewports *into the already-running app*
2. Close the viewports

A useful precursor: shortly before the crash one viewport renders **completely white**, ImGui overlay included. That is the same root cause one stage earlier — a viewport painting against a null/foreign ImGui context draws nothing.

Note that loading the same project via the startup CLI (`-f project.hsd`) does **not** reproduce it on either platform, which is what made this look load-related for a while.

## Verification

Windows: the fixed build survives repeated open/close cycles of 2- and 3-viewport projects with heavy interaction — no crash, no white viewports, no WER dump. Linux: same steps clean.

Split out of #22 so the confirmed fix can land independently of the GL-init hardening work in that PR, which is unrelated code (`render_widget.cpp`) and has no confirmed repro.
